### PR TITLE
Prevent forcing enable heating/cooling

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,11 +136,12 @@ interface of a device, under *Settings -> Device info -> Device ID*.
 #### Shelly 1AddOn configurations
 *Applies to Shelly 1, 1PM*
 * `"sensors"` - 1-3, number of sensors connected to the addon. (default: 0 , max: 3)
+* `"humidity"` - true|false, shows humitidy. (only applicable to one and first sensor)
 * `"excludeRelay"` - true|false, hiding the relay (switch) from homebridge. (default: false)
 
 * *For thermostat use:*
    * `"type"` - when the relais should act like a thermostat set the type to `"thermostat"` (default: undefined - expose switch & sensors if `"sensors"` > 0)
-   * `"humidity"` - false, shows humitidy (only applicable to one sensor)
+   * `"humidity"` - true|false, shows humitidy. (only applicable to one sensor) (default: false)
    * `"heating"` - true|false, enable heating on the thermostat. (default: true)
    * `"cooling"` - true|false, enable cooling on the thermostat. (default: false)
    * `"hysteresis"` - Sets a hysteresis at which difference the thermostat should switch on/off. (default: 0.5)

--- a/README.md
+++ b/README.md
@@ -139,7 +139,7 @@ interface of a device, under *Settings -> Device info -> Device ID*.
 * `"humidity"` - true|false, shows humitidy. (only applicable to one and first sensor)
 * `"excludeRelay"` - true|false, hiding the relay (switch) from homebridge. (default: false)
 
-* *For thermostat use:*
+*For thermostat use:*
    * `"type"` - when the relais should act like a thermostat set the type to `"thermostat"` (default: undefined - expose switch & sensors if `"sensors"` > 0)
    * `"humidity"` - true|false, shows humitidy. (only applicable to one sensor) (default: false)
    * `"heating"` - true|false, enable heating on the thermostat. (default: true)

--- a/README.md
+++ b/README.md
@@ -136,9 +136,9 @@ interface of a device, under *Settings -> Device info -> Device ID*.
 #### Shelly 1AddOn configurations
 *Applies to Shelly 1, 1PM*
 * `"sensors"` - 1-3, number of sensors connected to the addon. (default:0 , max: 3)
-* `"type"` - when the relais should act like a thermostat set the type to `"thermostat"`
+* `"type"` - when the relais should act like a temperature sensor set the type to `"thermostat"`, to act like a thermostat also set heating/cooling to `true`
 * `"humidity"` - false, shows humitidy (only applicable to one sensor)
-* `"heating"` - true|false, enable heating on the thermostat. (default: true)
+* `"heating"` - true|false, enable heating on the thermostat. (default: false)
 * `"cooling"` - true|false, enable cooling on the thermostat. (default: false)
 * `"hysteresis"` - Sets a hysteresis at which difference the thermostat should switch on/off. (default: 0.5)
 

--- a/README.md
+++ b/README.md
@@ -136,7 +136,7 @@ interface of a device, under *Settings -> Device info -> Device ID*.
 #### Shelly 1AddOn configurations
 *Applies to Shelly 1, 1PM*
 * `"sensors"` - 1-3, number of sensors connected to the addon. (default:0 , max: 3)
-* `"type"` - when the relais should act like a thermostat set the type to `"thermostat"` (default: undefined - expose switch & sensors if > 0)
+* `"type"` - when the relais should act like a thermostat set the type to `"thermostat"` (default: undefined - expose switch & sensors if `"sensors"` > 0)
 * `"humidity"` - false, shows humitidy (only applicable to one sensor)
 * `"heating"` - true|false, enable heating on the thermostat. (default: true)
 * `"cooling"` - true|false, enable cooling on the thermostat. (default: false)

--- a/README.md
+++ b/README.md
@@ -136,6 +136,7 @@ interface of a device, under *Settings -> Device info -> Device ID*.
 #### Shelly 1AddOn configurations
 *Applies to Shelly 1, 1PM*
 * `"sensors"` - 1-3, number of sensors connected to the addon. (default: 0 , max: 3)
+* `"excludeRelay"` - true|false, hiding the relay (switch) from HomeKit
 
 * *For thermostat use:*
    * `"type"` - when the relais should act like a thermostat set the type to `"thermostat"` (default: undefined - expose switch & sensors if `"sensors"` > 0)

--- a/README.md
+++ b/README.md
@@ -135,12 +135,14 @@ interface of a device, under *Settings -> Device info -> Device ID*.
 
 #### Shelly 1AddOn configurations
 *Applies to Shelly 1, 1PM*
-* `"sensors"` - 1-3, number of sensors connected to the addon. (default:0 , max: 3)
-* `"type"` - when the relais should act like a thermostat set the type to `"thermostat"` (default: undefined - expose switch & sensors if `"sensors"` > 0)
-* `"humidity"` - false, shows humitidy (only applicable to one sensor)
-* `"heating"` - true|false, enable heating on the thermostat. (default: true)
-* `"cooling"` - true|false, enable cooling on the thermostat. (default: false)
-* `"hysteresis"` - Sets a hysteresis at which difference the thermostat should switch on/off. (default: 0.5)
+* `"sensors"` - 1-3, number of sensors connected to the addon. (default: 0 , max: 3)
+
+* *For thermostat use:*
+   * `"type"` - when the relais should act like a thermostat set the type to `"thermostat"` (default: undefined - expose switch & sensors if `"sensors"` > 0)
+   * `"humidity"` - false, shows humitidy (only applicable to one sensor)
+   * `"heating"` - true|false, enable heating on the thermostat. (default: true)
+   * `"cooling"` - true|false, enable cooling on the thermostat. (default: false)
+   * `"hysteresis"` - Sets a hysteresis at which difference the thermostat should switch on/off. (default: 0.5)
 
 ### Example configuration
 ```json

--- a/README.md
+++ b/README.md
@@ -136,7 +136,7 @@ interface of a device, under *Settings -> Device info -> Device ID*.
 #### Shelly 1AddOn configurations
 *Applies to Shelly 1, 1PM*
 * `"sensors"` - 1-3, number of sensors connected to the addon. (default: 0 , max: 3)
-* `"excludeRelay"` - true|false, hiding the relay (switch) from HomeKit
+* `"excludeRelay"` - true|false, hiding the relay (switch) from homebridge
 
 * *For thermostat use:*
    * `"type"` - when the relais should act like a thermostat set the type to `"thermostat"` (default: undefined - expose switch & sensors if `"sensors"` > 0)

--- a/README.md
+++ b/README.md
@@ -136,9 +136,9 @@ interface of a device, under *Settings -> Device info -> Device ID*.
 #### Shelly 1AddOn configurations
 *Applies to Shelly 1, 1PM*
 * `"sensors"` - 1-3, number of sensors connected to the addon. (default:0 , max: 3)
-* `"type"` - when the relais should act like a temperature sensor set the type to `"thermostat"`, to act like a thermostat also set heating/cooling to `true`
+* `"type"` - when the relais should act like a thermostat set the type to `"thermostat"` (default: undefined - expose switch & sensors if > 0)
 * `"humidity"` - false, shows humitidy (only applicable to one sensor)
-* `"heating"` - true|false, enable heating on the thermostat. (default: false)
+* `"heating"` - true|false, enable heating on the thermostat. (default: true)
 * `"cooling"` - true|false, enable cooling on the thermostat. (default: false)
 * `"hysteresis"` - Sets a hysteresis at which difference the thermostat should switch on/off. (default: 0.5)
 

--- a/README.md
+++ b/README.md
@@ -136,7 +136,7 @@ interface of a device, under *Settings -> Device info -> Device ID*.
 #### Shelly 1AddOn configurations
 *Applies to Shelly 1, 1PM*
 * `"sensors"` - 1-3, number of sensors connected to the addon. (default: 0 , max: 3)
-* `"excludeRelay"` - true|false, hiding the relay (switch) from homebridge
+* `"excludeRelay"` - true|false, hiding the relay (switch) from homebridge. (default: false)
 
 * *For thermostat use:*
    * `"type"` - when the relais should act like a thermostat set the type to `"thermostat"` (default: undefined - expose switch & sensors if `"sensors"` > 0)

--- a/accessories/thermostat.js
+++ b/accessories/thermostat.js
@@ -8,9 +8,14 @@ module.exports = homebridge => {
       super('thermostat', device, index, config, log)
 
       const humidityEnabled = index === 0 && config.humidity
-      const heatingEnabled = config.heating || false
+      const heatingEnabled = config.heating || true
       const coolingEnabled = config.cooling || false
       const hysteresis = config.hysteresis || 0.5
+
+      if (!heatingEnabled && !coolingEnabled) {
+        throw new Error(`Invalid config, 
+          either cooling or heating should be true`)
+      }
 
       if (humidityEnabled && index !== 0) {
         throw new Error(`Invalid config, 

--- a/accessories/thermostat.js
+++ b/accessories/thermostat.js
@@ -8,14 +8,9 @@ module.exports = homebridge => {
       super('thermostat', device, index, config, log)
 
       const humidityEnabled = index === 0 && config.humidity
-      const heatingEnabled = config.heating || true
+      const heatingEnabled = config.heating || false
       const coolingEnabled = config.cooling || false
       const hysteresis = config.hysteresis || 0.5
-
-      if (!heatingEnabled && !coolingEnabled) {
-        throw new Error(`Invalid config, 
-          either cooling or heating should be true`)
-      }
 
       if (humidityEnabled && index !== 0) {
         throw new Error(`Invalid config, 


### PR DESCRIPTION
The device isn't a real thermostat (at least with basic configuration), so set default to act like a temperature sensor only.
Yet, let the user decide if they need the temperature controlling (by enabling heating/cooling).